### PR TITLE
[Feature Fix] Broken Tab Navigation

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route, useLocation } from "react-router-dom";
 import Header from "../../layout/Header";
 import Dashboard from "../../views/Dashboard";
 import Questions from "../../views/Questions";
@@ -7,7 +7,11 @@ import MyFeedback from "../../layout/Tabs/MyFeedback";
 import Auth from "../../views/Auth";
 
 function App() {
-  const [value, setValue] = useState(0);
+  const location = useLocation();
+
+  const [value, setValue] = useState(
+    location.pathname === "/" ? "/dashboard/share-feedback" : location.pathname // fix the hard coded bit?
+  );
   const [selectedUser, setSelectedUser] = useState(null);
 
   return (
@@ -27,7 +31,10 @@ function App() {
             />
           }
         />
-        <Route path="/dashboard" element={<Dashboard tabValue={value} />} />
+        <Route
+          path="/dashboard/:tab"
+          element={<Dashboard tabValue={value} />}
+        />
         <Route
           path="/user/:userid/question/:questionid"
           element={<Questions />}

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -10,7 +10,9 @@ function App() {
   const location = useLocation();
 
   const [value, setValue] = useState(
-    location.pathname === "/" ? "/dashboard/share-feedback" : location.pathname // fix the hard coded bit?
+    location.pathname === "/"
+      ? "share-feedback"
+      : location.pathname.split("/")[2] // fix the hard coded bit?
   );
   const [selectedUser, setSelectedUser] = useState(null);
 

--- a/src/layout/Header/DesktopHeader.js
+++ b/src/layout/Header/DesktopHeader.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import { HeaderContainer } from "./HeaderStyles";
 import UserAvatar from "../../ui/UserAvatar";
 import { Grid, Typography, Tab, Tabs } from "@mui/material";
@@ -18,11 +19,29 @@ function DesktopHeader({ sx, avatar, setTabValue, tabValue, selectedUser }) {
         >
           Feedback
         </Typography>
-        {selectedUser && (
+        {true && (
           <Tabs onChange={handleChange} value={tabValue}>
-            <Tab label="Share Feedback" id="share-feedback" />
-            <Tab label="My Feedback" id="my-feedback" />
-            <Tab label="Team Feedback" id="team-feedback" />
+            <Tab
+              component={Link}
+              value="/dashboard/share-feedback"
+              to="/dashboard/share-feedback"
+              label="Share Feedback"
+              id="share-feedback"
+            />
+            <Tab
+              component={Link}
+              to="/dashboard/my-feedback"
+              value="/dashboard/my-feedback"
+              label="My Feedback"
+              id="my-feedback"
+            />
+            <Tab
+              component={Link}
+              to="/dashboard/team-feedback"
+              value="/dashboard/team-feedback"
+              label="Team Feedback"
+              id="team-feedback"
+            />
           </Tabs>
         )}
         <UserAvatar src={avatar} alt="Gertie" />

--- a/src/layout/Header/DesktopHeader.js
+++ b/src/layout/Header/DesktopHeader.js
@@ -19,11 +19,11 @@ function DesktopHeader({ sx, avatar, setTabValue, tabValue, selectedUser }) {
         >
           Feedback
         </Typography>
-        {true && (
+        {selectedUser && (
           <Tabs onChange={handleChange} value={tabValue}>
             <Tab
               component={Link}
-              value="/dashboard/share-feedback"
+              value="share-feedback"
               to="/dashboard/share-feedback"
               label="Share Feedback"
               id="share-feedback"
@@ -31,14 +31,14 @@ function DesktopHeader({ sx, avatar, setTabValue, tabValue, selectedUser }) {
             <Tab
               component={Link}
               to="/dashboard/my-feedback"
-              value="/dashboard/my-feedback"
+              value="my-feedback"
               label="My Feedback"
               id="my-feedback"
             />
             <Tab
               component={Link}
               to="/dashboard/team-feedback"
-              value="/dashboard/team-feedback"
+              value="team-feedback"
               label="Team Feedback"
               id="team-feedback"
             />

--- a/src/views/Auth/Auth.js
+++ b/src/views/Auth/Auth.js
@@ -8,7 +8,7 @@ const Auth = ({ selectedUser, setSelectedUser }) => {
 
   useEffect(() => {
     if (selectedUser) {
-      navigate("/dashboard");
+      navigate("/dashboard/share-feedback");
     }
   }, [selectedUser, navigate]);
 

--- a/src/views/Dashboard/Dashboard.js
+++ b/src/views/Dashboard/Dashboard.js
@@ -1,20 +1,10 @@
 import React from "react";
-import { Button, Grid } from "@mui/material";
+import { Grid } from "@mui/material";
 import ShareFeedback from "../../layout/Tabs/ShareFeedback";
 import NoFeedback from "../../layout/Tabs/NoFeedback";
 import MyFeedback from "../../layout/Tabs/MyFeedback";
 
-import { useParams } from "react-router-dom";
-
 const Dashboard = ({ tabValue }) => {
-  console.log("TEST RENDERR");
-  const { tab } = useParams();
-
-  // console.log("TAB", tab);
-  // console.log("CHECK TAB VALUE", tabValue !== 0);
-  // console.log("CHECK TAB", tab !== "my-feedback");
-
-  // console.log("TAB VALUE", tabValue);
   return (
     <Grid
       sx={{
@@ -33,7 +23,7 @@ const Dashboard = ({ tabValue }) => {
         id="share-feedback"
         role="tabpanel"
         aria-labelledby="share feedback"
-        hidden={tabValue !== "/dashboard/share-feedback"}
+        hidden={tabValue !== "share-feedback"}
       >
         <ShareFeedback />
       </Grid>
@@ -45,7 +35,7 @@ const Dashboard = ({ tabValue }) => {
         id="my-feedback"
         role="tabpanel"
         aria-labelledby="my feedback"
-        hidden={tabValue !== "/dashboard/my-feedback"}
+        hidden={tabValue !== "my-feedback"}
       >
         <MyFeedback />
       </Grid>
@@ -54,7 +44,7 @@ const Dashboard = ({ tabValue }) => {
         id="team-feedback"
         role="tabpanel"
         aria-labelledby="team feedback"
-        hidden={tabValue !== "/dashboard/team-feedback"}
+        hidden={tabValue !== "team-feedback"}
       >
         <NoFeedback />
       </div>

--- a/src/views/Dashboard/Dashboard.js
+++ b/src/views/Dashboard/Dashboard.js
@@ -4,9 +4,17 @@ import ShareFeedback from "../../layout/Tabs/ShareFeedback";
 import NoFeedback from "../../layout/Tabs/NoFeedback";
 import MyFeedback from "../../layout/Tabs/MyFeedback";
 
-import { Link } from "react-router-dom";
+import { useParams } from "react-router-dom";
 
 const Dashboard = ({ tabValue }) => {
+  console.log("TEST RENDERR");
+  const { tab } = useParams();
+
+  // console.log("TAB", tab);
+  // console.log("CHECK TAB VALUE", tabValue !== 0);
+  // console.log("CHECK TAB", tab !== "my-feedback");
+
+  // console.log("TAB VALUE", tabValue);
   return (
     <Grid
       sx={{
@@ -24,7 +32,8 @@ const Dashboard = ({ tabValue }) => {
         }}
         id="share-feedback"
         role="tabpanel"
-        hidden={tabValue !== 0}
+        aria-labelledby="share feedback"
+        hidden={tabValue !== "/dashboard/share-feedback"}
       >
         <ShareFeedback />
       </Grid>
@@ -35,12 +44,18 @@ const Dashboard = ({ tabValue }) => {
         }}
         id="my-feedback"
         role="tabpanel"
-        hidden={tabValue !== 1}
+        aria-labelledby="my feedback"
+        hidden={tabValue !== "/dashboard/my-feedback"}
       >
         <MyFeedback />
       </Grid>
 
-      <div id="team-feedback" role="tabpanel" hidden={tabValue !== 2}>
+      <div
+        id="team-feedback"
+        role="tabpanel"
+        aria-labelledby="team feedback"
+        hidden={tabValue !== "/dashboard/team-feedback"}
+      >
         <NoFeedback />
       </div>
 

--- a/src/views/Dashboard/Dashboard.js
+++ b/src/views/Dashboard/Dashboard.js
@@ -22,7 +22,6 @@ const Dashboard = ({ tabValue }) => {
         }}
         id="share-feedback"
         role="tabpanel"
-        aria-labelledby="share feedback"
         hidden={tabValue !== "share-feedback"}
       >
         <ShareFeedback />
@@ -34,7 +33,6 @@ const Dashboard = ({ tabValue }) => {
         }}
         id="my-feedback"
         role="tabpanel"
-        aria-labelledby="my feedback"
         hidden={tabValue !== "my-feedback"}
       >
         <MyFeedback />
@@ -43,7 +41,6 @@ const Dashboard = ({ tabValue }) => {
       <div
         id="team-feedback"
         role="tabpanel"
-        aria-labelledby="team feedback"
         hidden={tabValue !== "team-feedback"}
       >
         <NoFeedback />


### PR DESCRIPTION
# Description

This PR fixes the broken tab navigation. Previously, selecting a tab would not change the URL. The tabs were also button elements

What this PR adds:
1. Tabs are links.
2. URL changes when new tab is clicked.
3. Sharing tab URL preselects the respective tab based on the URL.
4. Have the right ARIA roles

# Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Screenshots (if applicable)
![tabnavigation](https://user-images.githubusercontent.com/12892109/211007723-0cc2abdf-b9f2-4ceb-a9cd-c6e03db3cb2d.gif)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
